### PR TITLE
Add option --no-misp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options
   - `-h, --help` pour obtenir de l'aide
   - `-c CONFIG, --config CONFIG` pour spécifier un fichier de configuration `CONFIG` alternatif à `config/config.yaml`
   - `-n, --no-download` pour ne pas exécuter l'étape de téléchargement des fichiers JSON MISP, correspond à l'import des fichiers JSON MISP dans MISP
+  - `-m, --no-misp` pour ne pas exécuter l'étape d'import des fichiers JSON MISP dans MISP
   - `-d, --delete-local-directory-content` pour effacer le contenu du répertoire `local_directory` avant le téléchargement des fichiers JSON MISP
   - `-q, --quiet` pour réduire à une occurrence chaque message d'avertissement dans les fichiers de journalisation
   - `-v, --verbose` pour changer le niveau de verbosité de script
@@ -89,6 +90,7 @@ Options
   - `-h, --help` to get help
   - `-c CONFIG, --config CONFIG` Specify `CONFIG` as an alternative configuration file to `./conf/config.yaml`
   - `-n, --no-download ` Bypass JSON MISP files download, and just import the local JSON MISP files into MISP instance
+  - `-m, --no-misp ` Bypass the local JSON MISP files import into MISP instance
   - `-d, --delete-local-directory-content` Erase the content of the `local_directory` before JSON MISP files are downloaded
   - `-q, --quiet` Reduce spam in logs by showing warnings only once
   - `-v, --verbose` to change the script verbosity level

--- a/sftp2misp.py
+++ b/sftp2misp.py
@@ -77,6 +77,12 @@ def cli():
                 local JSON MISP files into MISP instance""",
     )
     parser.add_argument(
+        "-m",
+        "--no-misp",
+        action="store_true",
+        help="""Bypass local JSON MISP files import into MISP instance""",
+    )
+    parser.add_argument(
         "-d",
         "--delete-local-directory-content",
         action="store_true",
@@ -293,7 +299,10 @@ def main():
         warnings.filterwarnings("once")
     else:
         warnings.filterwarnings("always")
-    misp = misp_init(misp_c, logger)
+   
+    if not args.no_mips:
+        misp = misp_init(misp_c, logger)
+   
     proxy_command = ""
 
     if sftp_c["proxy_command"] != "":
@@ -318,7 +327,8 @@ def main():
                 misc_c["local_directory"],
                 logger,
             )
-    upload_events(misp, misc_c["local_directory"], logger)
+   if not args.no_mips:
+       upload_events(misp, misc_c["local_directory"], logger)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dans notre environnement, nous avons 2 serveurs MISP et MIRROR dans des zones différentes. Nous téléchargeons d'abord les fichiers MISP JSON sur le serveur MIRROR (avec l'option --no-misp) puis nous utilisons le script sur l'autre serveur MISP pour télécharger les fichiers JSON depuis notre serveur MIRROR et les injecter dans notre serveur MISP