### PR TITLE
use a meaningful name for the logger

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -93,7 +93,7 @@ def create_logger(config_log):
                 print("Unexpected error: ", sys.exc_info()[0])
                 raise
             logging.config.dictConfig(log_conf["LOGGING"])
-            logger = logging.getLogger("__name__")
+            logger = logging.getLogger("sftp2misp")
             logger.info("Configuration file loading completed")
             logging.captureWarnings(True)
             return logger

--- a/conf/logging.yaml
+++ b/conf/logging.yaml
@@ -19,7 +19,7 @@ LOGGING:
       backupCount: 20
       encoding: utf8
   loggers:
-    sampleLogger:
+    sftp2misp:
       level: INFO
       handlers:
         - file


### PR DESCRIPTION
"stfp2misp.upload_events()" is more explicit than "__name__.upload_events()"